### PR TITLE
feat: dataframe interchange protocol support

### DIFF
--- a/lazyscribe_arrow/csv.py
+++ b/lazyscribe_arrow/csv.py
@@ -9,6 +9,7 @@ from attrs import define
 from lazyscribe._utils import utcnow
 from lazyscribe.artifacts.base import Artifact
 from pyarrow import csv
+from pyarrow.interchange import from_dataframe
 from slugify import slugify
 
 LOG = logging.getLogger(__name__)
@@ -92,10 +93,13 @@ class CSVArtifact(Artifact):
             LOG.debug("Provided object is already a PyArrow table.")
         elif hasattr(obj, "__arrow_c_array__") or hasattr(obj, "__arrow_c_stream__"):
             obj = pa.table(obj)
+        elif hasattr(obj, "__dataframe__"):
+            obj = from_dataframe(obj)
         else:
             raise ValueError(
                 f"Object of type `{type(obj)}` cannot be easily coerced into a PyArrow Table. "
-                "Please provide an object that implements the Arrow PyCapsule Interface."
+                "Please provide an object that implements the Arrow PyCapsule Interface or the "
+                "Dataframe Interchange Protocol."
             )
 
         csv.write_csv(obj, buf, **kwargs)

--- a/tests/test_csv_handler.py
+++ b/tests/test_csv_handler.py
@@ -74,3 +74,39 @@ def test_csv_handler_raise_error(tmp_path):
     # we can't assert that the file does not exist since ``open`` creates the file,
     # even if there isn't any data
     assert (location / handler.fname).stat().st_size == 0
+
+
+@time_machine.travel(
+    datetime(2025, 1, 20, 13, 23, 30, tzinfo=zoneinfo.ZoneInfo("UTC")), tick=False
+)
+def test_csv_dataframe_interchange(tmp_path):
+    """Test using a data structure with dataframe interchange support."""
+
+    class MyDataStructure:
+        def __init__(self, data: pd.DataFrame):
+            """Init method."""
+            self.data = data
+
+        def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):
+            """The method for the dataframe interchange protocol."""
+            return self.data.__dataframe__(
+                nan_as_null=nan_as_null, allow_copy=allow_copy
+            )
+
+    location = tmp_path / "my-location"
+    location.mkdir()
+
+    data = pd.DataFrame({"key": ["value"]})
+    handler = CSVArtifact.construct(name="My output file")
+
+    assert handler.fname == "my-output-file-20250120132330.csv"
+
+    with open(location / handler.fname, "wb") as buf:
+        handler.write(MyDataStructure(data), buf)
+
+    assert (location / handler.fname).is_file()
+
+    with open(location / handler.fname, "rb") as buf:
+        out = handler.read(buf)
+
+    assert_frame_equal(data, out.to_pandas())


### PR DESCRIPTION
## Description

In this PR, I have added support for the dataframe interchange protocol. It's another way we can handle data structures that have specific compatibility with PyArrow.

Fixes #7 